### PR TITLE
Fix memory / PID leak when page navigation is timed out

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ SUSHII_IMG_QUALITY=70
 * [sushii bot]
 * [haseul bot]
 * [hyejoo bot]
+* [miso bot]
 * Use sushii-image-server? Feel free to open a PR to add to the list!
 
 [PM2]: https://github.com/Unitech/pm2
@@ -206,3 +207,4 @@ SUSHII_IMG_QUALITY=70
 [prom-client]: https://github.com/siimon/prom-client
 [sushii bot]: https://github.com/sushiibot/sushii-2
 [haseul bot]: https://github.com/twoscott/haseul-bot
+[miso bot]: https://github.com/joinemm/miso-bot


### PR DESCRIPTION
The opened page isn't being closed in case of timeout error, causing it to remain open forever. This was causing heavy memory leaks when requests frequently timed out, killing my bot.

docker stats after 24 hours of uptime
![2021-06-15_15-57](https://user-images.githubusercontent.com/26210439/122176871-be19bb00-ce8d-11eb-8152-861c15c480df.png)

This patch is a simple fix by just wrapping the function in a `try {} finally {}`
